### PR TITLE
fix if statement in systemd-boot-install-fedora-no-secureboot.sh

### DIFF
--- a/systemd-boot-install-fedora-no-secureboot.sh
+++ b/systemd-boot-install-fedora-no-secureboot.sh
@@ -21,10 +21,10 @@ function log {
 # Create the /tmp/${IDENTIFIER}/ folder
 mkdir -p /tmp/${IDENTIFIER}/
 
-if [[ ${?} -gt 0 ]];
+if [[ ${?} -gt 0 ]]; then
 	log "Creating the /tmp/${IDENTIFIER}/ folder failed with error code ${?}. Aborting."
 	exit 1
-then
+fi
 
 log "Before running this script make sure your system is fully up to date!"
 


### PR DESCRIPTION
I had an issue when launching the [systemd-boot-install-fedora-no-secureboot.sh](https://github.com/sebastiaanfranken/systemd-boot-conversion/blob/main/systemd-boot-install-fedora-no-secureboot.sh) script  gave me the `syntax error: unexpected end of file` error. <p> Fixing the if statement when [the script checked if the tmp folder was created successfully](https://github.com/sebastiaanfranken/systemd-boot-conversion/blob/dce2dab4478e22a3e7c3be60bec6f7070e2ecf74/systemd-boot-install-fedora-no-secureboot.sh#L24) fixed the error for me.